### PR TITLE
Implement quote cart mock feature

### DIFF
--- a/app/admin/quotes/page.tsx
+++ b/app/admin/quotes/page.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Download } from "lucide-react"
+import { useAuthStore, useQuoteStore } from "@/lib/store"
+
+export default function AdminQuotes() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+  const { quotes, updateStatus } = useQuoteStore()
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    }
+  }, [isAuthenticated, router])
+
+  if (!isAuthenticated) {
+    return null
+  }
+
+  const exportCSV = () => {
+    const headers = ["ชื่อ", "เบอร์", "หมายเหตุ", "สถานะ"]
+    const rows = quotes.map((q) => [q.name, q.phone, q.message, q.status])
+    const csv = [headers, ...rows].map((r) => r.map((f) => `"${f}"`).join(",")).join("\n")
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+    const link = document.createElement("a")
+    link.href = URL.createObjectURL(blob)
+    link.download = `quotes_${new Date().toISOString().split("T")[0]}.csv`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  const statusBadge = (status: string) => {
+    switch (status) {
+      case "ใหม่":
+        return "destructive"
+      case "กำลังตอบ":
+        return "default"
+      case "ปิดการขาย":
+        return "secondary"
+      default:
+        return "outline"
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <div className="flex justify-between items-center">
+          <h1 className="text-3xl font-bold font-sarabun">คำขอใบเสนอราคา</h1>
+          <Button onClick={exportCSV}>
+            <Download className="w-4 h-4 mr-2" /> Export as CSV
+          </Button>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">รายการคำขอ ({quotes.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="font-sarabun">ชื่อ</TableHead>
+                  <TableHead className="font-sarabun">เบอร์</TableHead>
+                  <TableHead className="font-sarabun">หมายเหตุ</TableHead>
+                  <TableHead className="font-sarabun">สถานะ</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {quotes.map((q) => (
+                  <TableRow key={q.id}>
+                    <TableCell className="font-sarabun">{q.name}</TableCell>
+                    <TableCell className="font-sarabun">{q.phone}</TableCell>
+                    <TableCell className="font-sarabun">{q.message}</TableCell>
+                    <TableCell>
+                      <Select value={q.status} onValueChange={(v) => updateStatus(q.id, v as any)}>
+                        <SelectTrigger className="w-32">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="ใหม่">ใหม่</SelectItem>
+                          <SelectItem value="กำลังตอบ">กำลังตอบ</SelectItem>
+                          <SelectItem value="ปิดการขาย">ปิดการขาย</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import Link from "next/link"
+import { useQuoteCartStore } from "@/lib/store"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Plus, Minus, Trash2 } from "lucide-react"
+
+export default function CartPage() {
+  const { items, updateQuantity, removeItem } = useQuoteCartStore()
+
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+
+  if (items.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <p className="text-gray-500 font-sarabun">ยังไม่มีสินค้าในคำขอ</p>
+          <Button asChild>
+            <Link href="/products">เลือกสินค้า</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <h1 className="text-3xl font-bold mb-4 font-sarabun">ตะกร้าคำขอใบเสนอราคา</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">รายการสินค้า</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {items.map((item) => (
+              <div key={`${item.productId}-${item.size}`} className="flex justify-between items-center border p-3 rounded-lg">
+                <div className="font-sarabun">
+                  <div>{item.productName}</div>
+                  <div className="text-sm text-gray-600">ขนาด: {item.size}"</div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => updateQuantity(item.productId, item.size, item.quantity - 1)}>
+                    <Minus className="w-3 h-3" />
+                  </Button>
+                  <span className="w-6 text-center">{item.quantity}</span>
+                  <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => updateQuantity(item.productId, item.size, item.quantity + 1)}>
+                    <Plus className="w-3 h-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon" className="text-red-600" onClick={() => removeItem(item.productId, item.size)}>
+                    <Trash2 className="w-3 h-3" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+            <Separator />
+            <div className="flex justify-between font-bold">
+              <span className="font-sarabun">รวม</span>
+              <span className="text-blue-600">฿{total.toLocaleString()}</span>
+            </div>
+          </CardContent>
+        </Card>
+        <Button asChild className="w-full">
+          <Link href="/quote">ถัดไป</Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/components/ui/separator"
 import { CheckCircle, Shield, Award } from "lucide-react"
 import { products } from "@/lib/mockData"
 import { useEffect } from "react"
+import { useQuoteCartStore } from "@/lib/store"
 // Add Facebook Pixel tracking for product views
 // import { fbPixelTrack } from "@/components/FacebookPixel" // TODO implement
 
@@ -21,6 +22,7 @@ interface ProductPageProps {
 
 export default function ProductPage({ params }: ProductPageProps) {
   const product = products.find((p) => p.slug === params.slug)
+  const { addItem } = useQuoteCartStore()
 
   if (!product) {
     notFound()
@@ -110,8 +112,20 @@ export default function ProductPage({ params }: ProductPageProps) {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4">
-              <Button asChild size="lg" className="flex-1">
-                <Link href={`/order?product=${product.slug}`}>ขอใบเสนอราคา</Link>
+              <Button
+                size="lg"
+                className="flex-1"
+                onClick={() =>
+                  addItem({
+                    productId: product.id,
+                    productName: product.name,
+                    size: product.sizes[0],
+                    quantity: 1,
+                    price: product.basePrice,
+                  })
+                }
+              >
+                เพิ่มลงคำขอ
               </Button>
               <Button asChild variant="outline" size="lg">
                 <Link href="tel:0-2925-9633">โทรสอบถาม</Link>

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -14,12 +14,14 @@ import { Slider } from "@/components/ui/slider"
 import { Search, Filter, Grid, List } from "lucide-react"
 import { products } from "@/lib/mockData"
 import { FadeInSection, SlideInSection } from "@/components/AnimatedComponents"
+import { useQuoteCartStore } from "@/lib/store"
 
 type SortOption = "name" | "price-low" | "price-high" | "type"
 type ViewMode = "grid" | "list"
 
 export default function ProductsPage() {
   const searchParams = useSearchParams()
+  const { addItem } = useQuoteCartStore()
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedTypes, setSelectedTypes] = useState<string[]>([])
   const [selectedMaterials, setSelectedMaterials] = useState<string[]>([])
@@ -362,8 +364,20 @@ export default function ProductsPage() {
                             <Button asChild className="flex-1" size="sm">
                               <Link href={`/products/${product.slug}`}>ดูรายละเอียด</Link>
                             </Button>
-                            <Button asChild variant="outline" size="sm">
-                              <Link href={`/order?product=${product.slug}`}>ขอใบเสนอราคา</Link>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                addItem({
+                                  productId: product.id,
+                                  productName: product.name,
+                                  size: product.sizes[0],
+                                  quantity: 1,
+                                  price: product.basePrice,
+                                })
+                              }
+                            >
+                              เพิ่มลงคำขอ
                             </Button>
                           </div>
                         </CardContent>
@@ -410,8 +424,20 @@ export default function ProductsPage() {
                                 <Button asChild size="sm">
                                   <Link href={`/products/${product.slug}`}>ดูรายละเอียด</Link>
                                 </Button>
-                                <Button asChild variant="outline" size="sm">
-                                  <Link href={`/order?product=${product.slug}`}>ขอใบเสนอราคา</Link>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() =>
+                                    addItem({
+                                      productId: product.id,
+                                      productName: product.name,
+                                      size: product.sizes[0],
+                                      quantity: 1,
+                                      price: product.basePrice,
+                                    })
+                                  }
+                                >
+                                  เพิ่มลงคำขอ
                                 </Button>
                               </div>
                             </div>

--- a/app/quote/page.tsx
+++ b/app/quote/page.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useQuoteCartStore, useQuoteStore } from "@/lib/store"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Separator } from "@/components/ui/separator"
+import { toast } from "@/hooks/use-toast"
+
+export default function QuotePage() {
+  const { items, clearCart } = useQuoteCartStore()
+  const { addQuote } = useQuoteStore()
+  const [form, setForm] = useState({ name: "", phone: "", message: "" })
+
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+  const shipping = total < 500 ? 50 : total <= 1000 ? 80 : 120
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (items.length === 0) return
+    const data = { ...form, items }
+    console.log("Quote request:", data)
+    addQuote(data)
+    toast({ title: "ส่งคำขอแล้ว", description: "เราจะติดต่อกลับโดยเร็วที่สุด" })
+    clearCart()
+    setForm({ name: "", phone: "", message: "" })
+  }
+
+  return (
+    <div className="min-h-screen py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <h1 className="text-3xl font-bold font-sarabun">สรุปคำขอใบเสนอราคา</h1>
+        {items.length === 0 ? (
+          <p className="text-gray-500 font-sarabun">ยังไม่มีสินค้าในคำขอ</p>
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle className="font-sarabun">รายการสินค้า</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {items.map((item) => (
+                <div key={`${item.productId}-${item.size}`} className="flex justify-between">
+                  <div className="font-sarabun">
+                    {item.productName} ({item.size}") × {item.quantity}
+                  </div>
+                  <div>฿{(item.price * item.quantity).toLocaleString()}</div>
+                </div>
+              ))}
+              <Separator />
+              <div className="flex justify-between font-bold">
+                <span className="font-sarabun">ยอดสินค้า</span>
+                <span>฿{total.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between font-sarabun">
+                <span>ค่าส่งโดยประมาณ*</span>
+                <span>฿{shipping.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between font-bold">
+                <span className="font-sarabun">รวมทั้งหมด</span>
+                <span>฿{(total + shipping).toLocaleString()}</span>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">ข้อมูลผู้ติดต่อ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="name" className="font-sarabun">ชื่อ-นามสกุล</label>
+                <Input id="name" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} required />
+              </div>
+              <div>
+                <label htmlFor="phone" className="font-sarabun">เบอร์โทร</label>
+                <Input id="phone" value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} required />
+              </div>
+              <div>
+                <label htmlFor="message" className="font-sarabun">หมายเหตุ</label>
+                <Textarea id="message" rows={3} value={form.message} onChange={(e) => setForm({ ...form, message: e.target.value })} />
+              </div>
+              <Button type="submit" className="w-full">ส่งคำขอใบเสนอราคา</Button>
+            </form>
+          </CardContent>
+        </Card>
+        <p className="text-sm text-gray-500 font-sarabun">*ค่าส่งโดยประมาณ</p>
+        {items.length === 0 && (
+          <Button asChild className="w-full">
+            <Link href="/products">เลือกสินค้า</Link>
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,11 +8,12 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Badge } from "@/components/ui/badge"
 import { Menu, Phone, Mail, ShoppingCart, Search } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { useQuoteCartStore } from "@/lib/store"
 
 const navigation = [
   { name: "หน้าแรก", href: "/" },
   { name: "สินค้า", href: "/products" },
-  { name: "ขอใบเสนอราคา", href: "/order" },
+  { name: "ขอใบเสนอราคา", href: "/quote" },
   { name: "เกี่ยวกับเรา", href: "/about" },
   { name: "ติดต่อ", href: "/contact" },
 ]
@@ -21,6 +22,7 @@ export function Navbar() {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
+  const { items } = useQuoteCartStore()
 
   useEffect(() => {
     const handleScroll = () => {
@@ -96,11 +98,18 @@ export function Navbar() {
               <Button variant="ghost" size="sm" className="hidden sm:flex">
                 <Search className="w-4 h-4" />
               </Button>
-              <Button variant="ghost" size="sm" className="hidden sm:flex">
-                <ShoppingCart className="w-4 h-4" />
+              <Button variant="ghost" size="sm" asChild className="hidden sm:flex relative">
+                <Link href="/cart">
+                  <ShoppingCart className="w-4 h-4" />
+                  {items.length > 0 && (
+                    <span className="absolute -top-2 -right-2 bg-red-600 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
+                      {items.length}
+                    </span>
+                  )}
+                </Link>
               </Button>
               <Button asChild size="sm" className="hidden sm:flex bg-blue-600 hover:bg-blue-700">
-                <Link href="/order">ขอใบเสนอราคา</Link>
+                <Link href="/quote">ขอใบเสนอราคา</Link>
               </Button>
 
               {/* Mobile Menu */}
@@ -127,7 +136,7 @@ export function Navbar() {
                     ))}
                     <div className="pt-4 border-t">
                       <Button asChild className="w-full bg-blue-600 hover:bg-blue-700">
-                        <Link href="/order" onClick={() => setIsOpen(false)}>
+                        <Link href="/quote" onClick={() => setIsOpen(false)}>
                           ขอใบเสนอราคา
                         </Link>
                       </Button>

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -533,3 +533,82 @@ export const mockLeads: Lead[] = [
     createdAt: "2024-01-18T16:30:00Z",
   },
 ]
+
+export interface QuoteItem {
+  productId: string
+  productName: string
+  size: string
+  quantity: number
+  price: number
+}
+
+export interface QuoteRequest {
+  id: string
+  name: string
+  phone: string
+  message: string
+  items: QuoteItem[]
+  status: "ใหม่" | "กำลังตอบ" | "ปิดการขาย"
+  createdAt: string
+}
+
+export const mockQuotes: QuoteRequest[] = [
+  {
+    id: "1",
+    name: "คุณสมชาย วิศวกร",
+    phone: "081-234-5678",
+    message: "ต้องการใบเสนอราคาด่วน",
+    items: [
+      {
+        productId: "3",
+        productName: "Conduit Bodies - Type C Standard",
+        size: "1/2",
+        quantity: 10,
+        price: 380,
+      },
+      {
+        productId: "5",
+        productName: "Conduit Bodies - Type LB Premium",
+        size: "1",
+        quantity: 5,
+        price: 640,
+      },
+    ],
+    status: "ใหม่",
+    createdAt: "2024-02-01T10:00:00Z",
+  },
+  {
+    id: "2",
+    name: "คุณนิรันดร์ ช่างไฟ",
+    phone: "082-345-6789",
+    message: "สอบถามราคาและระยะเวลาจัดส่ง",
+    items: [
+      {
+        productId: "1",
+        productName: "Conduit Bodies - Explosion-Proof Type C",
+        size: "3/4",
+        quantity: 20,
+        price: 1250,
+      },
+    ],
+    status: "กำลังตอบ",
+    createdAt: "2024-02-02T12:30:00Z",
+  },
+  {
+    id: "3",
+    name: "คุณวิชัย ผู้จัดการ",
+    phone: "083-456-7890",
+    message: "สั่งซื้อจำนวนมาก",
+    items: [
+      {
+        productId: "4",
+        productName: "Conduit Bodies - Type C Heavy Duty",
+        size: "1",
+        quantity: 50,
+        price: 320,
+      },
+    ],
+    status: "ปิดการขาย",
+    createdAt: "2024-02-03T09:15:00Z",
+  },
+]


### PR DESCRIPTION
## Summary
- create quote cart and quote store
- show cart icon badge and update order links
- add cart page and quote submission page with shipping mock logic
- admin view for quotes with CSV export
- enable adding products to quote request

## Testing
- `pnpm lint` *(fails: ESLint setup prompt)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6873e5f096b8832582fdfc7969ba07c4