### PR TITLE
Add mock analytics features and customer logos

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -10,6 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { XAxis, YAxis, CartesianGrid, ResponsiveContainer, PieChart, Pie, Cell, AreaChart, Area } from "recharts"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { Eye, Users, MousePointer, Clock, Activity } from "lucide-react"
+import { useLeadStore, useQuoteStore } from "@/lib/store"
 
 // Mock analytics data
 const realtimeData = {
@@ -78,6 +79,13 @@ export default function AdvancedAnalyticsPage() {
   const [selectedTimeRange, setSelectedTimeRange] = useState("7d")
   const [isRealtime, setIsRealtime] = useState(true)
 
+  const { leads } = useLeadStore();
+  const { quotes } = useQuoteStore();
+  const totalLeads = leads.length;
+  const totalQuotes = quotes.length;
+  const closedQuotes = quotes.filter(q => q.status === "ปิดการขาย").length;
+  const closeRate = totalQuotes ? Math.round((closedQuotes / totalQuotes) * 100) : 0;
+  const latestQuote = quotes[0];
   // Simulate real-time updates
   useEffect(() => {
     if (isRealtime) {
@@ -125,6 +133,32 @@ export default function AdvancedAnalyticsPage() {
             Real-time
           </Button>
         </div>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+        <Card>
+          <CardContent className="p-6">
+            <p className="text-sm text-gray-600">จำนวน Leads</p>
+            <p className="text-2xl font-bold">{totalLeads}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <p className="text-sm text-gray-600">จำนวน Quotes</p>
+            <p className="text-2xl font-bold">{totalQuotes}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <p className="text-sm text-gray-600">อัตราปิดการขาย</p>
+            <p className="text-2xl font-bold">{closeRate}%</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <p className="text-sm text-gray-600">ล่าสุด</p>
+            <p className="text-sm">{latestQuote ? new Date(latestQuote.createdAt).toLocaleDateString("th-TH") : "-"}</p>
+          </CardContent>
+        </Card>
+      </div>
       </div>
 
       {/* Real-time Overview */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,8 @@ import { Search, Phone, Mail, MapPin, CheckCircle, Shield, Award, Users, Clock, 
 import { products } from "@/lib/mockData"
 import { AnimatedCounter, FadeInSection, SlideInSection } from "@/components/AnimatedComponents"
 import { useToast } from "@/hooks/use-toast"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import FloatingContact from "@/components/FloatingContact"
 
 export default function HomePage() {
   const [searchTerm, setSearchTerm] = useState("")
@@ -337,6 +339,30 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+      {/* Client Logos */}
+      <section className="py-16 bg-gray-50">
+        <div className="container mx-auto px-4">
+          <FadeInSection>
+            <div className="text-center mb-8">
+              <h2 className="text-3xl lg:text-4xl font-bold text-slate-900 mb-4 font-sarabun">ลูกค้าที่เคยใช้บริการ</h2>
+              <p className="text-lg text-gray-600 font-sarabun">ตัวอย่างลูกค้าบางส่วนที่ไว้วางใจเรา</p>
+            </div>
+          </FadeInSection>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 items-center">
+            {[1,2,3,4,5,6].map((n) => (
+              <TooltipProvider key={n}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Image src="/placeholder-logo.png" alt={`Client ${n}`} width={150} height={80} className="mx-auto grayscale hover:grayscale-0 transition-all" />
+                  </TooltipTrigger>
+                  <TooltipContent className="font-sarabun">บริษัทตัวอย่าง {n}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ))}
+          </div>
+        </div>
+      </section>
+
 
       {/* Contact Section */}
       <section className="py-16 bg-blue-900 text-white">
@@ -455,6 +481,7 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+    <FloatingContact />
     </div>
   )
 }

--- a/components/FloatingContact.tsx
+++ b/components/FloatingContact.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { Facebook } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { MESSENGER_URL, LINE_URL } from "@/config/mock";
+
+export default function FloatingContact() {
+  return (
+    <div className="fixed bottom-6 right-6 flex flex-col gap-3 z-50">
+      <Link href={MESSENGER_URL} target="_blank" rel="noopener noreferrer">
+        <span className="w-12 h-12 flex items-center justify-center rounded-full bg-blue-600 hover:bg-blue-700 shadow-lg">
+          <Facebook className="text-white w-6 h-6" />
+        </span>
+      </Link>
+      <Link href={LINE_URL} target="_blank" rel="noopener noreferrer">
+        <span className="w-12 h-12 flex items-center justify-center rounded-full bg-green-500 hover:bg-green-600 shadow-lg">
+          <Image src="/placeholder-logo.png" alt="LINE" width={24} height={24} />
+        </span>
+      </Link>
+    </div>
+  );
+}

--- a/config/mock.ts
+++ b/config/mock.ts
@@ -1,0 +1,2 @@
+export const MESSENGER_URL = "https://m.me/example";
+export const LINE_URL = "https://line.me/R/ti/p/%40example";

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -79,16 +79,15 @@ export const useLeadStore = create<LeadState>()(
     (set) => ({
       leads: mockLeads,
       addLead: (lead) =>
-        set((state) => ({
-          leads: [
-            {
-              ...lead,
-              id: Date.now().toString(),
-              createdAt: new Date().toISOString(),
-            },
-            ...state.leads,
-          ],
-        })),
+        set((state) => {
+          const newLead: Lead = {
+            ...lead,
+            id: Date.now().toString(),
+            createdAt: new Date().toISOString(),
+          }
+          mockLeads.unshift(newLead)
+          return { leads: [newLead, ...state.leads] }
+        }),
       updateLead: (id, updatedLead) =>
         set((state) => ({
           leads: state.leads.map((lead) => (lead.id === id ? { ...lead, ...updatedLead } : lead)),
@@ -204,17 +203,16 @@ export const useQuoteStore = create<QuoteState>()(
     (set) => ({
       quotes: mockQuotes,
       addQuote: (quote) =>
-        set((state) => ({
-          quotes: [
-            {
-              ...quote,
-              id: Date.now().toString(),
-              status: "ใหม่",
-              createdAt: new Date().toISOString(),
-            },
-            ...state.quotes,
-          ],
-        })),
+        set((state) => {
+          const newQuote: QuoteRequest = {
+            ...quote,
+            id: Date.now().toString(),
+            status: "ใหม่" as QuoteRequest["status"],
+            createdAt: new Date().toISOString(),
+          }
+          mockQuotes.unshift(newQuote)
+          return { quotes: [newQuote, ...state.quotes] }
+        }),
       updateStatus: (id, status) =>
         set((state) => ({
           quotes: state.quotes.map((q) =>


### PR DESCRIPTION
## Summary
- store leads and quotes in mock arrays with timestamps
- add floating Messenger/LINE buttons
- show placeholder client logos on home page
- extend admin analytics with basic stats
- expose messenger/line link config

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873e99182008325a3ae55e2eb57aad7