### PR TITLE
Implement customer API and integration

### DIFF
--- a/SYSTEM_NOTES.md
+++ b/SYSTEM_NOTES.md
@@ -1,0 +1,5 @@
+/api/customers (GET, POST) - Customer List & Create API - done
+/api/customers/[id] (GET) - Get Customer by ID - done
+/api/customers/[id] (PUT) - Update Customer - done
+/api/customers/[id] (DELETE) - Delete Customer - done
+Zustand Store -> Customer API - done

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -11,14 +11,16 @@ import { useAuthStore, useCustomerStore } from "@/lib/store"
 export default function AdminCustomers() {
   const router = useRouter()
   const { isAuthenticated } = useAuthStore()
-  const { customers } = useCustomerStore()
+  const { customers, fetchCustomers } = useCustomerStore()
   const [query, setQuery] = useState("")
 
   useEffect(() => {
     if (!isAuthenticated) {
       router.push("/admin/login")
+    } else {
+      fetchCustomers()
     }
-  }, [isAuthenticated, router])
+  }, [isAuthenticated, router, fetchCustomers])
 
   if (!isAuthenticated) {
     return null

--- a/app/api/customers/[id]/route.ts
+++ b/app/api/customers/[id]/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+import { z } from 'zod'
+
+const dataFile = path.join(process.cwd(), 'data', 'customers.json')
+
+async function readData() {
+  try {
+    const data = await fs.readFile(dataFile, 'utf-8')
+    return JSON.parse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(dataFile), { recursive: true })
+      await fs.writeFile(dataFile, '[]', 'utf-8')
+      return []
+    }
+    throw err
+  }
+}
+
+async function writeData(customers: any[]) {
+  await fs.writeFile(dataFile, JSON.stringify(customers, null, 2))
+}
+
+const updateSchema = z.object({
+  name: z.string().optional(),
+  phone: z.string().optional(),
+  address: z.string().optional(),
+  contactCount: z.number().optional(),
+})
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const customers = await readData()
+  const customer = customers.find((c: any) => c.id === params.id)
+  if (!customer) return NextResponse.json({ error: 'not found' }, { status: 404 })
+  return NextResponse.json(customer)
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const customers = await readData()
+  const idx = customers.findIndex((c: any) => c.id === params.id)
+  if (idx === -1)
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  const body = await request.json()
+  const data = updateSchema.parse(body)
+  customers[idx] = { ...customers[idx], ...data }
+  await writeData(customers)
+  return NextResponse.json(customers[idx])
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const customers = await readData()
+  const newCustomers = customers.filter((c: any) => c.id !== params.id)
+  if (newCustomers.length === customers.length)
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  await writeData(newCustomers)
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+import { z } from 'zod'
+
+const dataFile = path.join(process.cwd(), 'data', 'customers.json')
+
+async function readData() {
+  try {
+    const data = await fs.readFile(dataFile, 'utf-8')
+    return JSON.parse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(dataFile), { recursive: true })
+      await fs.writeFile(dataFile, '[]', 'utf-8')
+      return []
+    }
+    throw err
+  }
+}
+
+async function writeData(customers: any[]) {
+  await fs.writeFile(dataFile, JSON.stringify(customers, null, 2))
+}
+
+const customerSchema = z.object({
+  name: z.string().min(1),
+  phone: z.string().min(5),
+  address: z.string().optional(),
+  from: z.enum(['lead', 'quote']),
+  contactCount: z.number().optional(),
+})
+
+export async function GET() {
+  const customers = await readData()
+  return NextResponse.json(customers)
+}
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  const data = customerSchema.parse(body)
+  const customers = await readData()
+  const exists = customers.some(
+    (c: any) => c.phone === data.phone && c.from === data.from
+  )
+  if (exists) {
+    return NextResponse.json({ error: 'exists' }, { status: 400 })
+  }
+  const newCustomer = {
+    ...data,
+    id: Date.now().toString(),
+    joinedAt: new Date().toISOString(),
+    contactCount: data.contactCount ?? 1,
+  }
+  customers.unshift(newCustomer)
+  await writeData(customers)
+  return NextResponse.json(newCustomer, { status: 201 })
+}

--- a/data/customers.json
+++ b/data/customers.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "1710000000001",
+    "name": "\u0e1a\u0e23\u0e34\u0e29\u0e31\u0e17 \u0e40\u0e2d \u0e08\u0e33\u0e01\u0e31\u0e14",
+    "phone": "0899999999",
+    "address": "123 \u0e2a\u0e38\u0e02\u0e38\u0e21\u0e27\u0e34\u0e17",
+    "from": "lead",
+    "joinedAt": "2024-05-01T00:00:00.000Z",
+    "contactCount": 1
+  },
+  {
+    "id": "1710000000002",
+    "name": "\u0e04\u0e38\u0e13\u0e2a\u0e21\u0e0a\u0e32\u0e22 \u0e43\u0e08\u0e14\u0e35",
+    "phone": "0812345678",
+    "address": "456 \u0e16\u0e19\u0e19\u0e1e\u0e23\u0e30\u0e23\u0e32\u0e21 2",
+    "from": "quote",
+    "joinedAt": "2024-05-10T00:00:00.000Z",
+    "contactCount": 2
+  }
+]

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -617,6 +617,7 @@ export interface Customer {
   id: string
   name: string
   phone: string
+  address?: string
   from: "lead" | "quote"
   joinedAt: string
   contactCount: number


### PR DESCRIPTION
## Summary
- add REST API under `/api/customers` using `data/customers.json`
- support CRUD operations for customers
- extend `Customer` type with optional address
- fetch customers from API in zustand store
- load real customer data on admin customers page
- log new routes in `SYSTEM_NOTES.md`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b56a035b08325857507e61906943b