### PR TITLE
Add workflow automation mock UI

### DIFF
--- a/SYSTEM_NOTES.md
+++ b/SYSTEM_NOTES.md
@@ -3,3 +3,9 @@
 /api/customers/[id] (PUT) - Update Customer - done
 /api/customers/[id] (DELETE) - Delete Customer - done
 Zustand Store -> Customer API - done
+Workflow Automation System mock UI:
+- Block 031: /admin/automation/rules - rule builder
+- Block 032: trigger event listener with console.log
+- Block 033: /admin/automation/actions - send broadcast action
+- Block 034: auto create support ticket action
+- Block 035: /admin/automation/log - view event/action history

--- a/app/admin/automation/actions/page.tsx
+++ b/app/admin/automation/actions/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAuthStore, useAutomationStore } from "@/lib/store"
+
+export default function AutomationActions() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+  const { sendBroadcast, triggerEvent } = useAutomationStore()
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    }
+  }, [isAuthenticated, router])
+
+  if (!isAuthenticated) return null
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">Automation Actions</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Button onClick={() => sendBroadcast()}>ส่งข้อความ Broadcast (mock)</Button>
+            <Button variant="secondary" onClick={() => triggerEvent("order_created")}>Trigger order_created Event</Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/automation/log/page.tsx
+++ b/app/admin/automation/log/page.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { useAuthStore, useAutomationStore } from "@/lib/store"
+
+export default function AutomationLog() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+  const { logs } = useAutomationStore()
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    }
+  }, [isAuthenticated, router])
+
+  if (!isAuthenticated) return null
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">Automation Log</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Message</TableHead>
+                  <TableHead>Timestamp</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {logs.map((l) => (
+                  <TableRow key={l.id}>
+                    <TableCell className="font-sarabun">{l.message}</TableCell>
+                    <TableCell className="font-sarabun">{new Date(l.timestamp).toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/automation/page.tsx
+++ b/app/admin/automation/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAuthStore } from "@/lib/store"
+
+export default function AutomationHome() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    }
+  }, [isAuthenticated, router])
+
+  if (!isAuthenticated) return null
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">Workflow Automation</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 font-sarabun">
+            <p><Link href="/admin/automation/rules" className="text-blue-600 underline">Workflow Rule Builder</Link></p>
+            <p><Link href="/admin/automation/actions" className="text-blue-600 underline">Trigger Actions</Link></p>
+            <p><Link href="/admin/automation/log" className="text-blue-600 underline">Monitor & Log</Link></p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/automation/rules/page.tsx
+++ b/app/admin/automation/rules/page.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { useAuthStore, useAutomationStore } from "@/lib/store"
+
+export default function AutomationRules() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+  const { rules, addRule, deleteRule } = useAutomationStore()
+  const [newRule, setNewRule] = useState({ event: "order_created", action: "send_broadcast" as const })
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    }
+  }, [isAuthenticated, router])
+
+  if (!isAuthenticated) return null
+
+  const handleAdd = () => {
+    addRule(newRule.event, newRule.action)
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">Workflow Rule Builder</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex gap-2 items-end">
+              <div className="w-1/2">
+                <label className="font-sarabun mb-1 block">If Event</label>
+                <Select value={newRule.event} onValueChange={(v) => setNewRule((r) => ({ ...r, event: v }))}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select event" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="order_created">order_created</SelectItem>
+                    <SelectItem value="support_request">support_request</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="w-1/2">
+                <label className="font-sarabun mb-1 block">Then Action</label>
+                <Select value={newRule.action} onValueChange={(v) => setNewRule((r) => ({ ...r, action: v as any }))}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select action" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="send_broadcast">send_broadcast</SelectItem>
+                    <SelectItem value="create_ticket">create_ticket</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button onClick={handleAdd}>Add Rule</Button>
+            </div>
+
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Event</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rules.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="font-sarabun">{r.event}</TableCell>
+                    <TableCell className="font-sarabun">{r.action}</TableCell>
+                    <TableCell>
+                      <Button variant="destructive" size="sm" onClick={() => deleteRule(r.id)}>
+                        Delete
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -47,6 +47,93 @@ export const useAuthStore = create<AuthState>()(
   ),
 )
 
+// Workflow Automation Store
+interface AutomationRule {
+  id: string
+  event: string
+  action: "send_broadcast" | "create_ticket"
+}
+
+interface AutomationLog {
+  id: string
+  message: string
+  timestamp: string
+}
+
+interface AutomationState {
+  rules: AutomationRule[]
+  logs: AutomationLog[]
+  addRule: (event: string, action: AutomationRule["action"]) => void
+  deleteRule: (id: string) => void
+  triggerEvent: (event: string) => void
+  sendBroadcast: () => void
+  createTicket: () => void
+}
+
+export const useAutomationStore = create<AutomationState>()(
+  persist(
+    (set, get) => ({
+      rules: [],
+      logs: [],
+      addRule: (event, action) =>
+        set((state) => ({
+          rules: [
+            ...state.rules,
+            { id: Date.now().toString(), event, action },
+          ],
+        })),
+      deleteRule: (id) =>
+        set((state) => ({
+          rules: state.rules.filter((r) => r.id !== id),
+        })),
+      triggerEvent: (event) => {
+        console.log("Event triggered:", event)
+        set((state) => ({
+          logs: [
+            { id: Date.now().toString(), message: `Event: ${event}`,
+timestamp: new Date().toISOString() },
+            ...state.logs,
+          ],
+        }))
+        const { rules, sendBroadcast, createTicket } = get()
+        rules
+          .filter((r) => r.event === event)
+          .forEach((r) => {
+            if (r.action === "send_broadcast") sendBroadcast()
+            if (r.action === "create_ticket") createTicket()
+          })
+      },
+      sendBroadcast: () => {
+        console.log("Sending broadcast message")
+        set((state) => ({
+          logs: [
+            {
+              id: Date.now().toString(),
+              message: "Action: send broadcast",
+              timestamp: new Date().toISOString(),
+            },
+            ...state.logs,
+          ],
+        }))
+      },
+      createTicket: () => {
+        console.log("Creating support ticket")
+        set((state) => ({
+          logs: [
+            {
+              id: Date.now().toString(),
+              message: "Action: create support ticket",
+              timestamp: new Date().toISOString(),
+            },
+            ...state.logs,
+          ],
+        }))
+      },
+    }),
+    { name: "automation-storage" },
+  ),
+)
+
 // Product Store
 interface ProductState {
   products: Product[]


### PR DESCRIPTION
## Summary
- add Zustand store for automation rules and logs
- add workflow automation admin pages
- document blocks 031-035 in SYSTEM_NOTES

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b65cec1908325b014535305383b1e