### PR TITLE
Implement tagging system with API and admin tools

### DIFF
--- a/app/admin/automation/tags/page.tsx
+++ b/app/admin/automation/tags/page.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useAuthStore, useTagStore } from "@/lib/store"
+
+interface Rule { threshold: number; tag: string }
+
+export default function AutomationTags() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+  const { tags, fetchTags } = useTagStore()
+  const [rules, setRules] = useState<Rule[]>([])
+  const [threshold, setThreshold] = useState("")
+  const [selectedTag, setSelectedTag] = useState("")
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    } else {
+      fetchTags()
+    }
+  }, [isAuthenticated, router, fetchTags])
+
+  if (!isAuthenticated) return null
+
+  const addRule = () => {
+    if (!threshold || !selectedTag) return
+    setRules([...rules, { threshold: Number(threshold), tag: selectedTag }])
+    setThreshold("")
+    setSelectedTag("")
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <h1 className="text-3xl font-bold font-sarabun">Automation Rules (Mock)</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">Add Rule</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex gap-4 items-end">
+              <Input
+                placeholder="Total >"
+                value={threshold}
+                onChange={(e) => setThreshold(e.target.value)}
+                className="w-32"
+              />
+              <Select value={selectedTag} onValueChange={setSelectedTag}>
+                <SelectTrigger className="w-40">
+                  <SelectValue placeholder="Tag" />
+                </SelectTrigger>
+                <SelectContent>
+                  {tags.map((t) => (
+                    <SelectItem key={t} value={t}>
+                      {t}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button onClick={addRule}>Add</Button>
+            </div>
+            <ul className="list-disc pl-5 space-y-1">
+              {rules.map((r, idx) => (
+                <li key={idx} className="font-sarabun">
+                  ยอดมากกว่า {r.threshold.toLocaleString()} → ติดแท็ก {r.tag}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -6,21 +6,25 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
-import { useAuthStore, useCustomerStore } from "@/lib/store"
+import { useAuthStore, useCustomerStore, useTagStore } from "@/lib/store"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 
 export default function AdminCustomers() {
   const router = useRouter()
   const { isAuthenticated } = useAuthStore()
-  const { customers, fetchCustomers } = useCustomerStore()
+  const { customers, fetchCustomers, updateCustomer } = useCustomerStore()
+  const { tags, fetchTags } = useTagStore()
   const [query, setQuery] = useState("")
+  const [filterTag, setFilterTag] = useState("all")
 
   useEffect(() => {
     if (!isAuthenticated) {
       router.push("/admin/login")
     } else {
       fetchCustomers()
+      fetchTags()
     }
-  }, [isAuthenticated, router, fetchCustomers])
+  }, [isAuthenticated, router, fetchCustomers, fetchTags])
 
   if (!isAuthenticated) {
     return null
@@ -31,6 +35,9 @@ export default function AdminCustomers() {
       c.name.toLowerCase().includes(query.toLowerCase()) ||
       c.phone.includes(query)
     )
+    .filter((c) =>
+      filterTag === "all" ? true : (c.tags || []).includes(filterTag)
+    )
     .sort(
       (a, b) => new Date(b.joinedAt).getTime() - new Date(a.joinedAt).getTime()
     )
@@ -39,12 +46,27 @@ export default function AdminCustomers() {
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="container mx-auto px-4 space-y-6">
         <h1 className="text-3xl font-bold font-sarabun">รายชื่อลูกค้า</h1>
-        <Input
-          placeholder="ค้นหา..."
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          className="max-w-sm"
-        />
+        <div className="flex gap-4">
+          <Input
+            placeholder="ค้นหา..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="max-w-sm"
+          />
+          <Select value={filterTag} onValueChange={setFilterTag}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Tag" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">ทั้งหมด</SelectItem>
+              {tags.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <Card>
           <CardHeader>
             <CardTitle className="font-sarabun">
@@ -59,6 +81,7 @@ export default function AdminCustomers() {
                   <TableHead className="font-sarabun">เบอร์</TableHead>
                   <TableHead className="font-sarabun">ครั้งที่ติดต่อ</TableHead>
                   <TableHead className="font-sarabun">จาก</TableHead>
+                  <TableHead className="font-sarabun">แท็ก</TableHead>
                   <TableHead className="font-sarabun">วันที่</TableHead>
                 </TableRow>
               </TableHeader>
@@ -70,14 +93,33 @@ export default function AdminCustomers() {
                     <TableCell className="font-sarabun text-center">
                       {c.contactCount}
                     </TableCell>
-                    <TableCell>
-                      <Badge variant={c.from === "lead" ? "default" : "secondary"}>
-                        {c.from === "lead" ? "จาก lead" : "จาก quote"}
+                  <TableCell>
+                    <Badge variant={c.from === "lead" ? "default" : "secondary"}>
+                      {c.from === "lead" ? "จาก lead" : "จาก quote"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="space-x-1">
+                    {(c.tags || []).map((t) => (
+                      <Badge key={t} variant="outline" className="cursor-pointer" onClick={() => updateCustomer(c.id, { tags: (c.tags || []).filter(tag => tag !== t) })}>
+                        {t} ×
                       </Badge>
-                    </TableCell>
-                    <TableCell className="font-sarabun">
-                      {new Date(c.joinedAt).toLocaleDateString("th-TH")}
-                    </TableCell>
+                    ))}
+                    <Select onValueChange={(v) => updateCustomer(c.id, { tags: [...(c.tags || []), v] })}>
+                      <SelectTrigger className="w-24 h-6">
+                        <SelectValue placeholder="+" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {tags.filter((t) => !(c.tags || []).includes(t)).map((t) => (
+                          <SelectItem key={t} value={t}>
+                            {t}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell className="font-sarabun">
+                    {new Date(c.joinedAt).toLocaleDateString("th-TH")}
+                  </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { useAuthStore, useOrderStore, useTagStore } from "@/lib/store"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+export default function AdminOrders() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+  const { orders, fetchOrders, updateOrder } = useOrderStore()
+  const { tags, fetchTags } = useTagStore()
+  const [query, setQuery] = useState("")
+  const [filterTag, setFilterTag] = useState("all")
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    } else {
+      fetchOrders()
+      fetchTags()
+    }
+  }, [isAuthenticated, router, fetchOrders, fetchTags])
+
+  if (!isAuthenticated) return null
+
+  const filtered = orders
+    .filter((o) => o.customerName.toLowerCase().includes(query.toLowerCase()))
+    .filter((o) => (filterTag === "all" ? true : (o.tags || []).includes(filterTag)))
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 space-y-6">
+        <h1 className="text-3xl font-bold font-sarabun">Orders</h1>
+        <div className="flex gap-4">
+          <Input
+            placeholder="ค้นหา..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="max-w-sm"
+          />
+          <Select value={filterTag} onValueChange={setFilterTag}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Tag" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">ทั้งหมด</SelectItem>
+              {tags.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">Orders ({filtered.length})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="font-sarabun">ลูกค้า</TableHead>
+                  <TableHead className="font-sarabun">ยอด</TableHead>
+                  <TableHead className="font-sarabun">สถานะ</TableHead>
+                  <TableHead className="font-sarabun">แท็ก</TableHead>
+                  <TableHead className="font-sarabun">วันที่</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((o) => (
+                  <TableRow key={o.id}>
+                    <TableCell className="font-sarabun">{o.customerName}</TableCell>
+                    <TableCell className="font-sarabun">฿{o.total.toLocaleString()}</TableCell>
+                    <TableCell className="font-sarabun">{o.status}</TableCell>
+                    <TableCell className="space-x-1">
+                      {(o.tags || []).map((t) => (
+                        <Badge key={t} variant="outline" className="cursor-pointer" onClick={() => updateOrder(o.id, { tags: (o.tags || []).filter(tag => tag !== t) })}>
+                          {t} ×
+                        </Badge>
+                      ))}
+                      <Select onValueChange={(v) => updateOrder(o.id, { tags: [...(o.tags || []), v] })}>
+                        <SelectTrigger className="w-24 h-6">
+                          <SelectValue placeholder="+" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {tags.filter((t) => !(o.tags || []).includes(t)).map((t) => (
+                            <SelectItem key={t} value={t}>
+                              {t}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell className="font-sarabun">
+                      {new Date(o.createdAt).toLocaleDateString("th-TH")}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/api/customers/[id]/route.ts
+++ b/app/api/customers/[id]/route.ts
@@ -28,6 +28,7 @@ const updateSchema = z.object({
   phone: z.string().optional(),
   address: z.string().optional(),
   contactCount: z.number().optional(),
+  tags: z.array(z.string()).optional(),
 })
 
 export async function GET(

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -29,6 +29,7 @@ const customerSchema = z.object({
   address: z.string().optional(),
   from: z.enum(['lead', 'quote']),
   contactCount: z.number().optional(),
+  tags: z.array(z.string()).optional(),
 })
 
 export async function GET() {
@@ -51,6 +52,7 @@ export async function POST(request: Request) {
     id: Date.now().toString(),
     joinedAt: new Date().toISOString(),
     contactCount: data.contactCount ?? 1,
+    tags: data.tags ?? [],
   }
   customers.unshift(newCustomer)
   await writeData(customers)

--- a/app/api/orders/[id]/route.ts
+++ b/app/api/orders/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+
+const dataFile = path.join(process.cwd(), 'data', 'orders.json')
+
+async function readOrders() {
+  try {
+    const data = await fs.readFile(dataFile, 'utf-8')
+    return JSON.parse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(dataFile), { recursive: true })
+      await fs.writeFile(dataFile, '[]', 'utf-8')
+      return []
+    }
+    throw err
+  }
+}
+
+async function writeOrders(orders: any[]) {
+  await fs.writeFile(dataFile, JSON.stringify(orders, null, 2))
+}
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const orders = await readOrders()
+  const order = orders.find((o: any) => o.id === params.id)
+  if (!order) return NextResponse.json({ error: 'not found' }, { status: 404 })
+  return NextResponse.json(order)
+}
+
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  const body = await request.json()
+  const orders = await readOrders()
+  const idx = orders.findIndex((o: any) => o.id === params.id)
+  if (idx === -1) return NextResponse.json({ error: 'not found' }, { status: 404 })
+  orders[idx] = { ...orders[idx], ...body }
+  await writeOrders(orders)
+  return NextResponse.json(orders[idx])
+}

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+
+const dataFile = path.join(process.cwd(), 'data', 'orders.json')
+
+async function readOrders() {
+  try {
+    const data = await fs.readFile(dataFile, 'utf-8')
+    return JSON.parse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(dataFile), { recursive: true })
+      await fs.writeFile(dataFile, '[]', 'utf-8')
+      return []
+    }
+    throw err
+  }
+}
+
+async function writeOrders(orders: any[]) {
+  await fs.writeFile(dataFile, JSON.stringify(orders, null, 2))
+}
+
+export async function GET() {
+  const orders = await readOrders()
+  return NextResponse.json(orders)
+}
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  const orders = await readOrders()
+  const newOrder = { ...body, id: Date.now().toString(), createdAt: new Date().toISOString(), tags: [] }
+  orders.unshift(newOrder)
+  await writeOrders(orders)
+  return NextResponse.json(newOrder, { status: 201 })
+}

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+
+const dataFile = path.join(process.cwd(), 'data', 'tags.json')
+
+async function readTags() {
+  try {
+    const data = await fs.readFile(dataFile, 'utf-8')
+    return JSON.parse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(dataFile), { recursive: true })
+      await fs.writeFile(dataFile, '[]', 'utf-8')
+      return []
+    }
+    throw err
+  }
+}
+
+async function writeTags(tags: string[]) {
+  await fs.writeFile(dataFile, JSON.stringify(tags, null, 2))
+}
+
+export async function GET() {
+  const tags = await readTags()
+  return NextResponse.json(tags)
+}
+
+export async function POST(request: Request) {
+  const { name } = await request.json()
+  if (!name || typeof name !== 'string') {
+    return NextResponse.json({ error: 'invalid' }, { status: 400 })
+  }
+  const tags = await readTags()
+  if (!tags.includes(name)) {
+    tags.push(name)
+    await writeTags(tags)
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/data/customers.json
+++ b/data/customers.json
@@ -6,7 +6,8 @@
     "address": "123 \u0e2a\u0e38\u0e02\u0e38\u0e21\u0e27\u0e34\u0e17",
     "from": "lead",
     "joinedAt": "2024-05-01T00:00:00.000Z",
-    "contactCount": 1
+    "contactCount": 1,
+    "tags": ["VIP"]
   },
   {
     "id": "1710000000002",
@@ -15,6 +16,7 @@
     "address": "456 \u0e16\u0e19\u0e19\u0e1e\u0e23\u0e30\u0e23\u0e32\u0e21 2",
     "from": "quote",
     "joinedAt": "2024-05-10T00:00:00.000Z",
-    "contactCount": 2
+    "contactCount": 2,
+    "tags": []
   }
 ]

--- a/data/orders.json
+++ b/data/orders.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "O1",
+    "customerName": "บริษัท ABC",
+    "total": 10000,
+    "status": "pending",
+    "createdAt": "2024-07-01T00:00:00.000Z",
+    "tags": []
+  }
+]

--- a/data/tags.json
+++ b/data/tags.json
@@ -1,0 +1,4 @@
+[
+  "VIP",
+  "Late Payer"
+]

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -621,6 +621,7 @@ export interface Customer {
   from: "lead" | "quote"
   joinedAt: string
   contactCount: number
+  tags?: string[]
 }
 
 export const mockCustomers: Customer[] = []
@@ -632,6 +633,7 @@ export interface Invoice {
   items: QuoteItem[]
   amount: number
   createdAt: string
+  tags?: string[]
 }
 
 export const mockInvoiceHistory: Invoice[] = []

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -85,6 +85,7 @@ interface CustomerState {
       contactCount?: number
     }
   ) => Promise<void>
+  updateCustomer: (id: string, data: Partial<Customer>) => Promise<void>
 }
 
 export const useCustomerStore = create<CustomerState>((set) => ({
@@ -103,6 +104,19 @@ export const useCustomerStore = create<CustomerState>((set) => ({
     if (res.ok) {
       const newCustomer = await res.json()
       set((state) => ({ customers: [newCustomer, ...state.customers] }))
+    }
+  },
+  updateCustomer: async (id, data) => {
+    const res = await fetch(`/api/customers/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      set((state) => ({
+        customers: state.customers.map((c) => (c.id === id ? updated : c)),
+      }))
     }
   },
 }))
@@ -346,3 +360,65 @@ export const useInvoiceStore = create<InvoiceState>()(
     { name: "invoice-storage" },
   ),
 )
+
+// Tag Store
+interface TagState {
+  tags: string[]
+  fetchTags: () => Promise<void>
+  addTag: (name: string) => Promise<void>
+}
+
+export const useTagStore = create<TagState>((set) => ({
+  tags: [],
+  fetchTags: async () => {
+    const res = await fetch("/api/tags")
+    const data = await res.json()
+    set({ tags: data })
+  },
+  addTag: async (name) => {
+    await fetch("/api/tags", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    })
+    set((state) => ({ tags: state.tags.includes(name) ? state.tags : [...state.tags, name] }))
+  },
+}))
+
+// Order Store
+interface Order {
+  id: string
+  customerName: string
+  total: number
+  status: string
+  createdAt: string
+  tags?: string[]
+}
+
+interface OrderState {
+  orders: Order[]
+  fetchOrders: () => Promise<void>
+  updateOrder: (id: string, order: Partial<Order>) => Promise<void>
+}
+
+export const useOrderStore = create<OrderState>((set) => ({
+  orders: [],
+  fetchOrders: async () => {
+    const res = await fetch("/api/orders")
+    const data = await res.json()
+    set({ orders: data })
+  },
+  updateOrder: async (id, order) => {
+    const res = await fetch(`/api/orders/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(order),
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      set((state) => ({
+        orders: state.orders.map((o) => (o.id === id ? updated : o)),
+      }))
+    }
+  },
+}))


### PR DESCRIPTION
## Summary
- create tags API and JSON storage
- allow customers and orders to be tagged
- add tag filters on customer/order admin pages
- mock automation rule page for tag rules
- add zustand stores for tags and orders

## Testing
- `npm run lint` *(fails: react lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ba287c5208325a56d2584ca0e978d