### PR TITLE
Add financial reporting APIs and dashboard widgets

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,22 +1,45 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Users, ShoppingCart, TrendingUp, Clock } from "lucide-react"
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
+import {
+  BarChart,
+  Bar,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+} from "recharts"
+import { Users, ShoppingCart, TrendingUp, Clock, LineChart as LineChartIcon } from "lucide-react"
 import { useAuthStore, useLeadStore } from "@/lib/store"
 
 export default function AdminDashboard() {
   const router = useRouter()
   const { isAuthenticated } = useAuthStore()
   const { leads, fetchLeads } = useLeadStore()
+  const [sales, setSales] = useState<{ date: string; total: number }[]>([])
+  const [expenses, setExpenses] = useState<{ id: string; amount: number; date: string }[]>([])
+  const [customers, setCustomers] = useState<any[]>([])
+  const [payments, setPayments] = useState<any[]>([])
 
   useEffect(() => {
     if (!isAuthenticated) {
       router.push("/admin/login")
     } else {
       fetchLeads()
+      fetch("/api/reports/sales").then((res) => res.json()).then(setSales)
+      fetch("/api/reports/expenses").then((res) => res.json()).then(setExpenses)
+      fetch("/api/customers").then((res) => res.json()).then(setCustomers)
+      fetch("/api/payments").then((res) => res.json()).then(setPayments)
     }
   }, [isAuthenticated, router, fetchLeads])
 
@@ -31,12 +54,64 @@ export default function AdminDashboard() {
 
   const recentLeads = leads.slice(0, 5)
 
+  const today = new Date().toISOString().split("T")[0]
+  const salesMap = Object.fromEntries(sales.map((s) => [s.date, s.total]))
+  const expenseMap = expenses.reduce<Record<string, number>>((acc, e) => {
+    acc[e.date] = (acc[e.date] || 0) + e.amount
+    return acc
+  }, {})
+  const last7 = Array.from({ length: 7 }).map((_, i) => {
+    const d = new Date()
+    d.setDate(d.getDate() - (6 - i))
+    const key = d.toISOString().split("T")[0]
+    return {
+      date: key,
+      sales: salesMap[key] || 0,
+      expenses: expenseMap[key] || 0,
+    }
+  })
+
+  const todaySales = salesMap[today] || 0
+  const newCustomers = customers.filter((c) => c.joinedAt?.startsWith(today)).length
+  const newOrders = payments.filter((p) => p.uploadedAt?.startsWith(today)).length
+
   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="container mx-auto px-4">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-slate-900 mb-2 font-sarabun">Dashboard</h1>
           <p className="text-gray-600 font-sarabun">ภาพรวมการขายและ Leads</p>
+        </div>
+
+        {/* KPI Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium font-sarabun">ยอดขายวันนี้</CardTitle>
+              <TrendingUp className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">฿{todaySales.toLocaleString()}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium font-sarabun">ลูกค้าใหม่วันนี้</CardTitle>
+              <Users className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{newCustomers}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium font-sarabun">ออเดอร์ใหม่วันนี้</CardTitle>
+              <LineChartIcon className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{newOrders}</div>
+            </CardContent>
+          </Card>
         </div>
 
         {/* Stats Cards */}
@@ -85,6 +160,30 @@ export default function AdminDashboard() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Financial Chart */}
+        <Card className="mb-8">
+          <CardHeader>
+            <CardTitle className="font-sarabun">ยอดขาย / รายจ่าย 7 วัน</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ChartContainer
+              config={{ sales: { label: "Sales", color: "hsl(var(--chart-1))" }, expenses: { label: "Expenses", color: "hsl(var(--chart-2))" } }}
+              className="h-72"
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={last7}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="date" />
+                  <YAxis />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Bar dataKey="sales" fill="var(--color-sales)" name="Sales" />
+                  <Bar dataKey="expenses" fill="var(--color-expenses)" name="Expenses" />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartContainer>
+          </CardContent>
+        </Card>
 
         {/* Recent Leads */}
         <Card>

--- a/app/admin/reports/profit-loss/page.tsx
+++ b/app/admin/reports/profit-loss/page.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useAuthStore } from "@/lib/store"
+
+interface Expense {
+  id: string
+  amount: number
+  date: string
+  description: string
+  category: string
+}
+
+interface SaleSummary {
+  date: string
+  total: number
+}
+
+export default function ProfitLossPage() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+  const [sales, setSales] = useState<SaleSummary[]>([])
+  const [expenses, setExpenses] = useState<Expense[]>([])
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.push("/admin/login")
+    } else {
+      fetch("/api/reports/sales").then(res => res.json()).then(setSales)
+      fetch("/api/reports/expenses").then(res => res.json()).then(setExpenses)
+    }
+  }, [isAuthenticated, router])
+
+  if (!isAuthenticated) return null
+
+  const totalSales = sales.reduce((sum, s) => sum + s.total, 0)
+  const totalExpenses = expenses.reduce((sum, e) => sum + e.amount, 0)
+  const profit = totalSales - totalExpenses
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-sarabun">สรุปกำไรขาดทุน</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 font-sarabun">
+            <p>ยอดขายรวม: ฿{totalSales.toLocaleString()}</p>
+            <p>รายจ่ายรวม: ฿{totalExpenses.toLocaleString()}</p>
+            <p className="font-bold">กำไร: ฿{profit.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/api/reports/expenses/route.ts
+++ b/app/api/reports/expenses/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+import { z } from 'zod'
+
+const dataFile = path.join(process.cwd(), 'data', 'expenses.json')
+
+async function readData() {
+  try {
+    const data = await fs.readFile(dataFile, 'utf-8')
+    return JSON.parse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(dataFile), { recursive: true })
+      await fs.writeFile(dataFile, '[]', 'utf-8')
+      return []
+    }
+    throw err
+  }
+}
+
+async function writeData(expenses: any[]) {
+  await fs.writeFile(dataFile, JSON.stringify(expenses, null, 2))
+}
+
+const expenseSchema = z.object({
+  description: z.string(),
+  category: z.string(),
+  amount: z.number(),
+  date: z.string().optional(),
+})
+
+export async function GET() {
+  const expenses = await readData()
+  return NextResponse.json(expenses)
+}
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  const data = expenseSchema.parse(body)
+  const expenses = await readData()
+  const newExpense = {
+    ...data,
+    id: Date.now().toString(),
+    date: data.date || new Date().toISOString().split('T')[0],
+  }
+  expenses.unshift(newExpense)
+  await writeData(expenses)
+  return NextResponse.json(newExpense, { status: 201 })
+}

--- a/app/api/reports/sales/route.ts
+++ b/app/api/reports/sales/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+
+const paymentsFile = path.join(process.cwd(), 'data', 'payments.json')
+
+async function readPayments() {
+  try {
+    const data = await fs.readFile(paymentsFile, 'utf-8')
+    return JSON.parse(data)
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      await fs.mkdir(path.dirname(paymentsFile), { recursive: true })
+      await fs.writeFile(paymentsFile, '[]', 'utf-8')
+      return []
+    }
+    throw err
+  }
+}
+
+export async function GET() {
+  const payments = await readPayments()
+  const summary: Record<string, number> = {}
+  for (const p of payments) {
+    const date = p.uploadedAt ? p.uploadedAt.split('T')[0] : new Date().toISOString().split('T')[0]
+    summary[date] = (summary[date] || 0) + (p.amount || 0)
+  }
+  const result = Object.entries(summary).map(([date, total]) => ({ date, total }))
+  return NextResponse.json(result)
+}

--- a/data/expenses.json
+++ b/data/expenses.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "1",
+    "description": "ค่าโฆษณาออนไลน์",
+    "category": "Marketing",
+    "amount": 1500,
+    "date": "2024-05-01"
+  },
+  {
+    "id": "2",
+    "description": "ค่าขนส่งสินค้า",
+    "category": "Logistics",
+    "amount": 800,
+    "date": "2024-05-02"
+  }
+]


### PR DESCRIPTION
## Summary
- add mock expenses data
- create sales and expenses report APIs
- implement profit-loss admin page
- enhance dashboard with KPI cards and chart

## Testing
- `npm run lint` *(fails: multiple React lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687bb0de80ac83259df2f977e0bed961